### PR TITLE
docs: Add IPv6 limitation notice for WireGuard configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,8 @@ WIREGUARD_PRIVATE_KEY=
 
 # Your WireGuard IP addresses (comma-separated)
 # Example: 10.68.45.123/32,fc00:bbbb:bbbb:bb01::4:2d7a/128
+# IMPORTANT: Only use IPv4 address (e.g., 10.68.45.123/32)
+# IPv6 is not currently supported by Gluetun in this configuration
 WIREGUARD_ADDRESSES=
 
 # Public key of VPN server (required for custom providers only)


### PR DESCRIPTION
Closes #3

- Added clear warning that only IPv4 addresses should be used in WIREGUARD_ADDRESSES
- Documented that IPv6 is not currently supported by Gluetun
- Prevents configuration errors when users copy both IPv4 and IPv6 from Mullvad/ProtonVPN configs